### PR TITLE
Update mcp.emoji_support.php

### DIFF
--- a/emoji_support/README.md
+++ b/emoji_support/README.md
@@ -36,6 +36,10 @@ It's always good idea to check with the developer though, as it is possible that
 
 ## Change Log
 
+### 2.1.1
+
+- Skip exp_pro_search_index table.
+
 ### 2.1.0
 
 - Added EE6 support

--- a/emoji_support/mcp.emoji_support.php
+++ b/emoji_support/mcp.emoji_support.php
@@ -181,7 +181,7 @@ class Emoji_support_mcp {
 	{
 		$return = [];
 
-		$indicies = ee()->db->query("SELECT `TABLE_NAME`, `COLUMN_NAME` FROM `INFORMATION_SCHEMA`.`COLUMNS` WHERE `TABLE_SCHEMA` = '" . ee()->db->database . "' AND `DATA_TYPE` REGEXP 'char|text' AND `CHARACTER_MAXIMUM_LENGTH` > 191 AND `COLUMN_KEY` <> '' AND `COLUMN_NAME` NOT IN ('url_title', 'cat_group');");
+		$indicies = ee()->db->query("SELECT `TABLE_NAME`, `COLUMN_NAME` FROM `INFORMATION_SCHEMA`.`COLUMNS` WHERE `TABLE_SCHEMA` = '" . ee()->db->database . "' AND `DATA_TYPE` REGEXP 'char|text' AND `CHARACTER_MAXIMUM_LENGTH` > 191 AND `COLUMN_KEY` <> '' AND TABLE_NAME != 'pro_search_indexes' AND `COLUMN_NAME` NOT IN ('url_title', 'cat_group');");
 		if ($indicies->num_rows())
 		{
 			// check to see if the associated index is also over 191 characters

--- a/emoji_support/mcp.emoji_support.php
+++ b/emoji_support/mcp.emoji_support.php
@@ -181,7 +181,7 @@ class Emoji_support_mcp {
 	{
 		$return = [];
 
-		$indicies = ee()->db->query("SELECT `TABLE_NAME`, `COLUMN_NAME` FROM `INFORMATION_SCHEMA`.`COLUMNS` WHERE `TABLE_SCHEMA` = '" . ee()->db->database . "' AND `DATA_TYPE` REGEXP 'char|text' AND `CHARACTER_MAXIMUM_LENGTH` > 191 AND `COLUMN_KEY` <> '' AND TABLE_NAME != 'pro_search_indexes' AND `COLUMN_NAME` NOT IN ('url_title', 'cat_group');");
+		$indicies = ee()->db->query("SELECT `TABLE_NAME`, `COLUMN_NAME` FROM `INFORMATION_SCHEMA`.`COLUMNS` WHERE `TABLE_SCHEMA` = '" . ee()->db->database . "' AND `DATA_TYPE` REGEXP 'char|text' AND `CHARACTER_MAXIMUM_LENGTH` > 191 AND `COLUMN_KEY` <> '' AND TABLE_NAME != 'exp_pro_search_indexes' AND `COLUMN_NAME` NOT IN ('url_title', 'cat_group');");
 		if ($indicies->num_rows())
 		{
 			// check to see if the associated index is also over 191 characters

--- a/emoji_support/upd.emoji_support.php
+++ b/emoji_support/upd.emoji_support.php
@@ -16,7 +16,7 @@ class Emoji_support_upd {
 	{
 		ee('Model')->make('Module', [
 			'module_name' => 'Emoji_support',
-			'module_version' => '1.0.2',
+			'module_version' => '1.1.1',
 			'has_cp_backend' => TRUE,
 			'has_publish_fields' => FALSE
 		])->save();


### PR DESCRIPTION
Pro Search Indexes uses a FULLTEXT index, which is larger than Emoji Support wants any index to be. But it's actually OK, so let's exclude it.